### PR TITLE
Fixes missing viewpoint availability in Editor

### DIFF
--- a/bundles/org.dataflowanalysis.pcm.extension.pcm.ui/src/org/dataflowanalysis/pcm/extension/pcm/ui/PCMSiriusUtils.java
+++ b/bundles/org.dataflowanalysis.pcm.extension.pcm.ui/src/org/dataflowanalysis/pcm/extension/pcm/ui/PCMSiriusUtils.java
@@ -10,7 +10,6 @@ import org.eclipse.sirius.business.api.session.Session;
 public final class PCMSiriusUtils {
 
 	private static final String PCM_CONFIDENTIALITY_VIEWPOINT_NAME = "PCM-Confidentiality";
-	private static final String PCM_INDIRECTIONS_VIEWPOINT_NAME = "PCM-Indirections";
 
 	private PCMSiriusUtils() {
 		// intentionally left blank
@@ -23,6 +22,6 @@ public final class PCMSiriusUtils {
 
 	public static void enableSpecificViewpoints(Session session) {
 		SiriusUtils.enableViewpoints(session,
-				Arrays.asList(PCM_INDIRECTIONS_VIEWPOINT_NAME, PCM_CONFIDENTIALITY_VIEWPOINT_NAME));
+				Arrays.asList(PCM_CONFIDENTIALITY_VIEWPOINT_NAME));
 	}
 }

--- a/features/org.dataflowanalysis.pcm.extension.feature/feature.xml
+++ b/features/org.dataflowanalysis.pcm.extension.feature/feature.xml
@@ -177,4 +177,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.dataflowanalysis.pcm.extension.editor.sirius"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
This PR removes the activation of the indirections viewpoint from the editor and adds the sirius editor to the deployed feature on the updatesite