### PR TITLE
Update namespace uri for metamodels

### DIFF
--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl/src/org/dataflowanalysis/pcm/extension/dictionary/characterized/dsl/CharacterizedDataDictionary.xtext
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl/src/org/dataflowanalysis/pcm/extension/dictionary/characterized/dsl/CharacterizedDataDictionary.xtext
@@ -3,7 +3,7 @@ grammar org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.Characte
 import "platform:/resource/org.dataflowanalysis.pcm.extension.dictionary.characterized/model/DataDictionaryCharacterized.ecore"
 import "platform:/resource/org.dataflowanalysis.pcm.extension.dictionary.characterized/model/DataDictionaryCharacterized.ecore#//expressions" as ex
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
-import "http://palladiosimulator.org/dataflow/dictionary/1.0" as dd
+import "http://dataflowanalysis.org/pcm/extension/dictionary/1.0" as dd
 
 DataDictionaryCharacterized returns DataDictionaryCharacterized:
 	{DataDictionaryCharacterized}

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.edit/plugin.xml
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.edit/plugin.xml
@@ -9,7 +9,7 @@
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated DataDictionaryCharacterized -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/dictionary/characterized/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/1.0"
             class="org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.provider.DataDictionaryCharacterizedItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider
@@ -22,7 +22,7 @@
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated DataDictionaryCharacterized -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/dictionary/characterized/expressions/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/expressions/1.0"
             class="org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.provider.ExpressionsItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized/model/DataDictionaryCharacterized.ecore
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized/model/DataDictionaryCharacterized.ecore
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="DataDictionaryCharacterized" nsURI="http://palladiosimulator.org/dataflow/dictionary/characterized/1.0"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="DataDictionaryCharacterized" nsURI="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/1.0"
     nsPrefix="DataDictionaryCharacterized">
   <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
     <details key="settingDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL/LPG"/>
@@ -76,7 +76,7 @@
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>
-  <eSubpackages name="expressions" nsURI="http://palladiosimulator.org/dataflow/dictionary/characterized/expressions/1.0"
+  <eSubpackages name="expressions" nsURI="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/expressions/1.0"
       nsPrefix="expressions">
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="settingDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL/LPG"/>

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized/plugin.xml
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized/plugin.xml
@@ -8,7 +8,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated DataDictionaryCharacterized -->
       <package
-            uri="http://palladiosimulator.org/dataflow/dictionary/characterized/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/1.0"
             class="org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.DataDictionaryCharacterizedPackage"
             genModel="model/DataDictionaryCharacterized.genmodel"/>
    </extension>
@@ -16,7 +16,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated DataDictionaryCharacterized -->
       <package
-            uri="http://palladiosimulator.org/dataflow/dictionary/characterized/expressions/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/expressions/1.0"
             class="org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.expressions.ExpressionsPackage"
             genModel="model/DataDictionaryCharacterized.genmodel"/>
    </extension>

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.edit/plugin.xml
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.edit/plugin.xml
@@ -9,7 +9,7 @@
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated DataDictionary -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/dictionary/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/1.0"
             class="org.dataflowanalysis.pcm.extension.dictionary.DataDictionary.provider.DataDictionaryItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.editor.sirius/description/org.dataflowanalysis.pcm.extension.dictionary.editor.sirius.odesign
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.editor.sirius/description/org.dataflowanalysis.pcm.extension.dictionary.editor.sirius.odesign
@@ -2,7 +2,7 @@
 <description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:properties="http://www.eclipse.org/sirius/properties/1.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:tool="http://www.eclipse.org/sirius/diagram/description/tool/1.1.0" xmlns:tool_1="http://www.eclipse.org/sirius/description/tool/1.1.0" name="org.dataflowanalysis.pcm.extension.dictionary.editor.sirius" version="12.0.0.2017041100">
   <ownedViewpoints name="default">
     <ownedRepresentations xsi:type="description_1:DiagramDescription" name="Dictionary Editor" domainClass="DataDictionary::DataDictionary" enablePopupBars="true">
-      <metamodel href="http://palladiosimulator.org/dataflow/dictionary/1.0#/"/>
+      <metamodel href="http://dataflowanalysis.org/pcm/extension/dictionary/1.0#/"/>
       <defaultLayer name="Default">
         <nodeMappings name="PrimitiveDTNode" domainClass="DataDictionary::PrimitiveDataType">
           <style xsi:type="style:WorkspaceImageDescription" labelSize="12" showIcon="false" sizeComputationExpression="-1" labelPosition="node" resizeKind="NSEW" workspacePath="/org.dataflowanalysis.pcm.extension.dictionary.editor.sirius/icons/Primitive.svg">

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.ecore
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.ecore
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="DataDictionary" nsURI="http://palladiosimulator.org/dataflow/dictionary/1.0"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="DataDictionary" nsURI="http://dataflowanalysis.org/pcm/extension/dictionary/1.0"
     nsPrefix="DataDictionary">
   <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
     <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary/plugin.xml
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary/plugin.xml
@@ -11,7 +11,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated DataDictionary -->
       <package
-            uri="http://palladiosimulator.org/dataflow/dictionary/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/1.0"
             class="org.dataflowanalysis.pcm.extension.dictionary.DataDictionary.DataDictionaryPackage"
             genModel="model/DataDictionary.genmodel"/>
    </extension>

--- a/bundles/org.dataflowanalysis.pcm.extension.model.edit/plugin.xml
+++ b/bundles/org.dataflowanalysis.pcm.extension.model.edit/plugin.xml
@@ -9,7 +9,7 @@
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated dataFlowConfidentiality -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.provider.ConfidentialityItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider
@@ -29,7 +29,7 @@
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated dataFlowConfidentiality -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/characteristics"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/characteristics"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.characteristics.provider.CharacteristicsItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider
@@ -42,14 +42,14 @@
    <extension point="org.eclipse.emf.edit.childCreationExtenders">
       <!-- @generated dataFlowConfidentiality -->
       <extender
-            uri="http://palladiosimulator.org/dataflow/dictionary/characterized/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/1.0"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.characteristics.provider.CharacteristicsItemProviderAdapterFactory$DataDictionaryCharacterizedChildCreationExtender"/>
    </extension>
 
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated dataFlowConfidentiality -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/expression"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/expression"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.expression.provider.ExpressionItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider
@@ -62,17 +62,17 @@
    <extension point="org.eclipse.emf.edit.childCreationExtenders">
       <!-- @generated dataFlowConfidentiality -->
       <extender
-            uri="http://palladiosimulator.org/dataflow/dictionary/characterized/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/1.0"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.expression.provider.ExpressionItemProviderAdapterFactory$DataDictionaryCharacterizedChildCreationExtender"/>
       <extender
-            uri="http://palladiosimulator.org/dataflow/dictionary/characterized/expressions/1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/dictionary/characterized/expressions/1.0"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.expression.provider.ExpressionItemProviderAdapterFactory$ExpressionsChildCreationExtender"/>
    </extension>
 
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated dataFlowConfidentiality -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/behaviour"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/behaviour"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.behaviour.provider.BehaviourItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider
@@ -85,7 +85,7 @@
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated dataFlowConfidentiality -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/repository"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/repository"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.repository.provider.RepositoryItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider
@@ -105,7 +105,7 @@
    <extension point="org.eclipse.emf.edit.itemProviderAdapterFactories">
       <!-- @generated dataFlowConfidentiality -->
       <factory
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/dictionary"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/dictionary"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.dictionary.provider.DictionaryItemProviderAdapterFactory"
             supportedTypes=
               "org.eclipse.emf.edit.provider.IEditingDomainItemProvider

--- a/bundles/org.dataflowanalysis.pcm.extension.model/model/dataFlowConfidentiality.ecore
+++ b/bundles/org.dataflowanalysis.pcm.extension.model/model/dataFlowConfidentiality.ecore
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="confidentiality" nsURI="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="confidentiality" nsURI="http://dataflowanalysis.org/pcm/extension/model/0.1.0"
     nsPrefix="confidentiality">
   <eClassifiers xsi:type="ecore:EClass" name="ConfidentialityVariableCharacterisation"
       eSuperTypes="../../org.palladiosimulator.pcm/model/pcm.ecore#//parameter/VariableCharacterisation">
@@ -9,7 +9,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="rhs" lowerBound="1" eType="ecore:EClass ../../org.dataflowanalysis.pcm.extension.dictionary.characterized/model/DataDictionaryCharacterized.ecore#//expressions/Term"
         containment="true"/>
   </eClassifiers>
-  <eSubpackages name="characteristics" nsURI="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/characteristics"
+  <eSubpackages name="characteristics" nsURI="http://dataflowanalysis.org/pcm/extension/model/0.1.0/characteristics"
       nsPrefix="characteristics">
     <eClassifiers xsi:type="ecore:EClass" name="CharacteristicTypeDictionary" eSuperTypes="../../de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -65,7 +65,7 @@
       </eStructuralFeatures>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="expression" nsURI="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/expression"
+  <eSubpackages name="expression" nsURI="http://dataflowanalysis.org/pcm/extension/model/0.1.0/expression"
       nsPrefix="expression">
     <eClassifiers xsi:type="ecore:EClass" name="AbstractNamedReferenceReference" abstract="true">
       <eStructuralFeatures xsi:type="ecore:EReference" name="namedReference" lowerBound="1"
@@ -86,7 +86,7 @@
     <eClassifiers xsi:type="ecore:EClass" name="LhsDataTypeCharacteristicReference"
         eSuperTypes="#//expression/DataTypeCharacteristicReference #//expression/VariableCharacterizationLhs"/>
   </eSubpackages>
-  <eSubpackages name="behaviour" nsURI="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/behaviour"
+  <eSubpackages name="behaviour" nsURI="http://dataflowanalysis.org/pcm/extension/model/0.1.0/behaviour"
       nsPrefix="behaviour">
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="settingDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL/LPG"/>
@@ -147,7 +147,7 @@
           containment="true"/>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="repository" nsURI="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/repository"
+  <eSubpackages name="repository" nsURI="http://dataflowanalysis.org/pcm/extension/model/0.1.0/repository"
       nsPrefix="repository">
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL/LPG"/>
@@ -163,7 +163,7 @@
       </eAnnotations>
     </eClassifiers>
   </eSubpackages>
-  <eSubpackages name="dictionary" nsURI="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/dictionary"
+  <eSubpackages name="dictionary" nsURI="http://dataflowanalysis.org/pcm/extension/model/0.1.0/dictionary"
       nsPrefix="dictionary">
     <eClassifiers xsi:type="ecore:EClass" name="PCMDataDictionary" eSuperTypes="../../de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier #//characteristics/CharacteristicTypeDictionary #//characteristics/Characteristics #//behaviour/Behaviours"/>
   </eSubpackages>

--- a/bundles/org.dataflowanalysis.pcm.extension.model/plugin.xml
+++ b/bundles/org.dataflowanalysis.pcm.extension.model/plugin.xml
@@ -9,7 +9,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated dataFlowConfidentiality -->
       <package
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.ConfidentialityPackage"
             genModel="model/dataFlowConfidentiality.genmodel"/>
    </extension>
@@ -17,7 +17,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated dataFlowConfidentiality -->
       <package
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/characteristics"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/characteristics"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.characteristics.CharacteristicsPackage"
             genModel="model/dataFlowConfidentiality.genmodel"/>
    </extension>
@@ -25,7 +25,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated dataFlowConfidentiality -->
       <package
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/expression"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/expression"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.expression.ExpressionPackage"
             genModel="model/dataFlowConfidentiality.genmodel"/>
    </extension>
@@ -33,7 +33,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated dataFlowConfidentiality -->
       <package
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/behaviour"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/behaviour"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.behaviour.BehaviourPackage"
             genModel="model/dataFlowConfidentiality.genmodel"/>
    </extension>
@@ -41,7 +41,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated dataFlowConfidentiality -->
       <package
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/repository"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/repository"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.repository.RepositoryPackage"
             genModel="model/dataFlowConfidentiality.genmodel"/>
    </extension>
@@ -49,7 +49,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated dataFlowConfidentiality -->
       <package
-            uri="http://palladiosimulator.org/dataflow/confidentiality/pcm/0.1.0/dictionary"
+            uri="http://dataflowanalysis.org/pcm/extension/model/0.1.0/dictionary"
             class="org.dataflowanalysis.pcm.extension.model.confidentiality.dictionary.DictionaryPackage"
             genModel="model/dataFlowConfidentiality.genmodel"/>
    </extension>

--- a/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/workflow/GenerateCharacterizedDataDictionary.mwe2
+++ b/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/workflow/GenerateCharacterizedDataDictionary.mwe2
@@ -25,11 +25,6 @@ Workflow {
 			to = "platform:/resource/de.uka.ipd.sdq.identifier/model/identifier.genmodel"
 		}
 		
-//		uriMap = {
-//			from = "platform:/plugin/org.palladiosimulator.dataflow.diagram/model/DataFlowDiagram.genmodel"
-//			to = "platform:/resource/org.palladiosimulator.dataflow.diagram/model/DataFlowDiagram.genmodel"
-//		}
-		
 		uriMap = {
 			from = "platform:/plugin/org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.genmodel"
 			to = "platform:/resource/org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.genmodel"
@@ -39,11 +34,6 @@ Workflow {
 			from = "platform:/plugin/${dataDictionaryProjectName}/model/DataDictionaryCharacterized.genmodel"
 			to = "platform:/resource/${dataDictionaryProjectName}/model/DataDictionaryCharacterized.genmodel"
 		}
-		
-//		uriMap = {
-//			from = "platform:/plugin/${dataFlowDiagramProjectName}/model/DataFlowDiagramCharacterized.genmodel"
-//			to = "platform:/resource/${dataFlowDiagramProjectName}/model/DataFlowDiagramCharacterized.genmodel"
-//		}
 		
 		registerGenModelFile = "platform:/resource/de.uka.ipd.sdq.identifier/model/identifier.genmodel"
 	}
@@ -92,8 +82,6 @@ Workflow {
 				generateStub = false
 			}
 			validator = {
-				// composedCheck = "org.eclipse.xtext.validation.NamesAreUniqueValidator"
-				// Generates checks for @Deprecated grammar annotations, an IssueProvider and a corresponding PropertyPage
 				generateDeprecationValidation = true
 			}
 			generator = {

--- a/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/workflow/generate.mwe2
+++ b/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/workflow/generate.mwe2
@@ -48,4 +48,5 @@ Workflow {
 			gen = "platform:/resource/${dataDictionaryProjectName}.edit/src-gen"
 			src = "platform:/resource/${dataDictionaryProjectName}.edit/src"
 		}
+  }
 }

--- a/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/workflow/generate.mwe2
+++ b/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/workflow/generate.mwe2
@@ -24,23 +24,11 @@ Workflow {
 			from = "platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore"
 			to = "platform:/resource/de.uka.ipd.sdq.identifier/model/identifier.ecore"
 		}
-
-//		uriMap = {
-//			from = "platform:/plugin/org.palladiosimulator.dataflow.diagram/model/DataFlowDiagram.genmodel"
-//			to = "platform:/resource/org.palladiosimulator.dataflow.diagram/model/DataFlowDiagram.genmodel"
-//		}
 		
 		uriMap = {
 			from = "platform:/plugin/org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.genmodel"
 			to = "platform:/resource/org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.genmodel"
 		}
-		
-//		uriMap = {
-//			from = "platform:/plugin/${dataFlowDiagramProjectName}/model/DataDictionaryCharacterized.genmodel"
-//			to = "platform:/resource/${dataFlowDiagramProjectName}/model/DataDictionaryCharacterized.genmodel"
-//		}
-		
-//		logResourceUriMap = true
 		
 		registerGenModelFile = "platform:/resource/de.uka.ipd.sdq.identifier/model/identifier.genmodel"
 	}
@@ -54,36 +42,10 @@ Workflow {
 		srcPath = "platform:/resource/${dataDictionaryProjectName}.edit/src"
 		srcPath = "platform:/resource/${dataDictionaryProjectName}.editor/src"
 	}
-	
-//	component = EcoreGenerator {
-//		generateCustomClasses = false
-//		generateEdit = true
-//		generateEditor = true
-//		genModel = "platform:/resource/${dataFlowDiagramProjectName}/model/DataFlowDiagramCharacterized.genmodel"
-//		srcPath = "platform:/resource/${dataFlowDiagramProjectName}/src"
-//		srcPath = "platform:/resource/${dataFlowDiagramProjectName}.edit/src"
-//		srcPath = "platform:/resource/${dataFlowDiagramProjectName}.editor/src"
-//	}
 
 	component = GapPatternPostProcessor {
-		// dictionary
 		folders = {
 			gen = "platform:/resource/${dataDictionaryProjectName}.edit/src-gen"
 			src = "platform:/resource/${dataDictionaryProjectName}.edit/src"
 		}
-		// diagram
-//		folders = {
-//			gen = "platform:/resource/${dataFlowDiagramProjectName}/src-gen"
-//			src = "platform:/resource/${dataFlowDiagramProjectName}/src"
-//		}
-//		folders = {
-//			gen = "platform:/resource/${dataFlowDiagramProjectName}.edit/src-gen"
-//			src = "platform:/resource/${dataFlowDiagramProjectName}.edit/src"
-//		}
-//		folders = {
-//			gen = "platform:/resource/${dataFlowDiagramProjectName}.editor/src-gen"
-//			src = "platform:/resource/${dataFlowDiagramProjectName}.editor/src"
-//		}
-	}
-
 }

--- a/releng/org.dataflowanalysis.pcm.extension.mwe2/workflow/GenerateDDDsl.mwe2
+++ b/releng/org.dataflowanalysis.pcm.extension.mwe2/workflow/GenerateDDDsl.mwe2
@@ -14,11 +14,6 @@ Workflow {
 		scanClassPath = true
 		platformUri = workspaceRoot
 		
-//		uriMap = {
-//			from = "platform:/plugin/org.palladiosimulator.dataflow.diagram/model/DataFlowDiagram.genmodel"
-//			to = "platform:/resource/org.palladiosimulator.dataflow.diagram/model/DataFlowDiagram.genmodel"
-//		}
-		
 		uriMap = {
 			from = "platform:/plugin/org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.genmodel"
 			to = "platform:/resource/org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.genmodel"
@@ -28,12 +23,6 @@ Workflow {
 			from = "platform:/plugin/org.dataflowanalysis.pcm.extension.dictionary.characterized/model/DataDictionaryCharacterized.genmodel"
 			to = "platform:/resource/org.dataflowanalysis.pcm.extension.dictionary.characterized/model/DataDictionaryCharacterized.genmodel"
 		}
-		
-//		uriMap = {
-//			from = "platform:/plugin/org.palladiosimulator.dataflow.diagram.characterized/model/DataFlowDiagramCharacterized.genmodel"
-//			to = "platform:/resource/org.palladiosimulator.dataflow.diagram.characterized/model/DataFlowDiagramCharacterized.genmodel"
-//		}
-		
 		
 		uriMap = {
 			from = "platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.genmodel"
@@ -152,8 +141,6 @@ Workflow {
 				generateStub = false
 			}
 			validator = {
-				// composedCheck = "org.eclipse.xtext.validation.NamesAreUniqueValidator"
-				// Generates checks for @Deprecated grammar annotations, an IssueProvider and a corresponding PropertyPage
 				generateDeprecationValidation = true
 			}
 			generator = {


### PR DESCRIPTION
This PR updates the namespace URIs of all included metamodels to the new namespace. Changes downstream may be required due to references in the models to the older URI.
This PR closes #15 