### PR TITLE
Fix namespace and model objects of node assignments model

### DIFF
--- a/bundles/org.dataflowanalysis.pcm.extension.nodecharacteristics/model/nodeCharacteristics.ecore
+++ b/bundles/org.dataflowanalysis.pcm.extension.nodecharacteristics/model/nodeCharacteristics.ecore
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="nodecharacteristics" nsURI="http://www.example.org/nodeCharacteristics"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="nodecharacteristics" nsURI="http://dataflowanalysis.org/pcm/extension/nodecharacteristics/0.1.0"
     nsPrefix="nodecharacteristics">
   <eClassifiers xsi:type="ecore:EClass" name="UsageAssignee" eSuperTypes="#//AbstractAssignee platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
     <eStructuralFeatures xsi:type="ecore:EReference" name="usagescenario" lowerBound="1"

--- a/bundles/org.dataflowanalysis.pcm.extension.nodecharacteristics/model/nodeCharacteristics.ecore
+++ b/bundles/org.dataflowanalysis.pcm.extension.nodecharacteristics/model/nodeCharacteristics.ecore
@@ -2,15 +2,15 @@
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="nodecharacteristics" nsURI="http://www.example.org/nodeCharacteristics"
     nsPrefix="nodecharacteristics">
-  <eClassifiers xsi:type="ecore:EClass" name="UsageAsignee" eSuperTypes="#//AbstractAssignee">
+  <eClassifiers xsi:type="ecore:EClass" name="UsageAssignee" eSuperTypes="#//AbstractAssignee platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
     <eStructuralFeatures xsi:type="ecore:EReference" name="usagescenario" lowerBound="1"
         eType="ecore:EClass ../../org.palladiosimulator.pcm/model/pcm.ecore#//usagemodel/UsageScenario"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="RessourceAssignee" eSuperTypes="#//AbstractAssignee">
+  <eClassifiers xsi:type="ecore:EClass" name="RessourceAssignee" eSuperTypes="#//AbstractAssignee platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
     <eStructuralFeatures xsi:type="ecore:EReference" name="resourcecontainer" lowerBound="1"
         eType="ecore:EClass ../../org.palladiosimulator.pcm/model/pcm.ecore#//resourceenvironment/ResourceContainer"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="AssemblyAssignee" eSuperTypes="#//AbstractAssignee">
+  <eClassifiers xsi:type="ecore:EClass" name="AssemblyAssignee" eSuperTypes="#//AbstractAssignee platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
     <eStructuralFeatures xsi:type="ecore:EReference" name="assemblycontext" lowerBound="1"
         eType="ecore:EClass ../../org.palladiosimulator.pcm/model/pcm.ecore#//core/composition/AssemblyContext"/>
   </eClassifiers>

--- a/bundles/org.dataflowanalysis.pcm.extension.nodecharacteristics/model/nodeCharacteristics.genmodel
+++ b/bundles/org.dataflowanalysis.pcm.extension.nodecharacteristics/model/nodeCharacteristics.genmodel
@@ -7,9 +7,8 @@
     editPluginClass="org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.provider.NodeCharacteristicsEditPlugin"
     editorPluginClass="org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.presentation.NodeCharacteristicsEditorPlugin"
     rootExtendsInterface="org.eclipse.emf.cdo.CDOObject" rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl"
-    reflectiveDelegation="true"
-    importerID="org.eclipse.emf.importer.cdo" featureDelegation="Reflective" complianceLevel="5.0"
-    copyrightFields="false" providerRootExtendsClass="org.eclipse.emf.cdo.edit.CDOItemProviderAdapter"
+    suppressEMFTypes="true" reflectiveDelegation="true" importerID="org.eclipse.emf.importer.cdo"
+    featureDelegation="Reflective" complianceLevel="5.0" copyrightFields="false" providerRootExtendsClass="org.eclipse.emf.cdo.edit.CDOItemProviderAdapter"
     editPluginID="org.dataflowanalysis.pcm.extension.nodecharacteristics.edit" editorPluginID="org.dataflowanalysis.pcm.extension.nodecharacteristics.editor"
     usedGenPackages="../../org.dataflowanalysis.pcm.extension.dictionary/model/DataDictionary.genmodel#//DataDictionary ../../org.dataflowanalysis.pcm.extension.dictionary.characterized/model/DataDictionaryCharacterized.genmodel#//DataDictionaryCharacterized ../../org.dataflowanalysis.pcm.extension.model/model/dataFlowConfidentiality.genmodel#//confidentiality ../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../de.uka.ipd.sdq.identifier/model/identifier.genmodel#//identifier ../../org.palladiosimulator.pcm/model/pcm.genmodel#//pcm ../../de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel#//probfunction ../../de.uka.ipd.sdq.stoex/model/stoex.genmodel#//stoex ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
     importOrganizing="true">
@@ -19,8 +18,8 @@
   <genPackages prefix="NodeCharacteristics" basePackage="org.dataflowanalysis.pcm.extension.nodecharacteristics"
       resource="XMI" disposableProviderFactory="true" extensibleProviderFactory="true"
       ecorePackage="nodeCharacteristics.ecore#/">
-    <genClasses ecoreClass="nodeCharacteristics.ecore#//UsageAsignee">
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference nodeCharacteristics.ecore#//UsageAsignee/usagescenario"/>
+    <genClasses ecoreClass="nodeCharacteristics.ecore#//UsageAssignee">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference nodeCharacteristics.ecore#//UsageAssignee/usagescenario"/>
     </genClasses>
     <genClasses ecoreClass="nodeCharacteristics.ecore#//RessourceAssignee">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference nodeCharacteristics.ecore#//RessourceAssignee/resourcecontainer"/>


### PR DESCRIPTION
This PR fixes the namespace and model objects of the node assignments model. Furthermore, it enables the option to prefer using native classes, instead of EMF classes.

This issue resolves #17 