### PR TITLE
Update version numbers to 5.2.2

### DIFF
--- a/bundles/org.dataflowanalysis.pcm.extension.dddsl.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dddsl.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dddsl.ide
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dddsl.ide
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dddsl.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dddsl,

--- a/bundles/org.dataflowanalysis.pcm.extension.dddsl.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dddsl.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dddsl.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dddsl.ui
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dddsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dddsl,

--- a/bundles/org.dataflowanalysis.pcm.extension.dddsl/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dddsl/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dddsl
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dddsl
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dddsl; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.model;visibility:=reexport,

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characteriz
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ide
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl,

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characteriz
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl,

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characteriz
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dictionary.characterized,

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.edit/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized.edit;singleton:=true
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized.edit
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Activator: org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.provider.DataDictionaryCharacterizedEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.editor/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized.editor;singleton:=true
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized.editor
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Activator: org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.presentation.DataDictionaryCharacterizedEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.characterized/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized;singleton:=true
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.edit/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.edit;singleton:=true
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.edit
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Activator: org.dataflowanalysis.pcm.extension.dictionary.DataDictionary.provider.DataDictionaryEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.editor.sirius/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.editor.sirius/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.editor.sirius;singleton:=true
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-Activator: org.dataflowanalysis.pcm.extension.dictionary.editor.sirius.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary.editor/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.editor;singleton:=true
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.editor
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Activator: org.dataflowanalysis.pcm.extension.dictionary.DataDictionary.presentation.DataDictionaryEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/org.dataflowanalysis.pcm.extension.dictionary/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.dictionary/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary;singleton:=true
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.dataflowanalysis.pcm.extension.editor.sirius/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.editor.sirius/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.editor.sirius;singleton:=true
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-Activator: org.dataflowanalysis.pcm.extension.editor.sirius.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/bundles/org.dataflowanalysis.pcm.extension.model.edit/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.model.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.model.edit;singleton:=true
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.model.edit
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Activator: org.dataflowanalysis.pcm.extension.model.confidentiality.provider.DataFlowConfidentialityEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/org.dataflowanalysis.pcm.extension.model.editor/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.model.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.model.editor;singleton:=true
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.model.editor
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Activator: org.dataflowanalysis.pcm.extension.model.confidentiality.presentation.DataFlowConfidentialityEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/org.dataflowanalysis.pcm.extension.model/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.model;singleton:=true
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.dataflowanalysis.pcm.extension.pcm.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.pcm.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ui
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.pcm.ui;singleton:=true
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.pcm.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.dataflowanalysis.pcm.extension.ui,

--- a/bundles/org.dataflowanalysis.pcm.extension.queryutils/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.queryutils/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PCM Query Utils
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.queryutils
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.queryutils
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: com.google.guava,

--- a/bundles/org.dataflowanalysis.pcm.extension.ui.table/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.ui.table/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Data Flow Diagram UI Components
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.ui.table;singleton:=true
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.ui.table
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.eef.core,

--- a/bundles/org.dataflowanalysis.pcm.extension.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.dataflowanalysis.pcm.extension.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DataFlow Confidentiality UI
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.ui;singleton:=true
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui;bundle-version="3.118.0",

--- a/features/org.dataflowanalysis.pcm.extension.feature/feature.xml
+++ b/features/org.dataflowanalysis.pcm.extension.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.dataflowanalysis.pcm.extension.feature"
       label="Data Flow Analysis PCM Extension Feature"
-      version="5.2.1.qualifier">
+      version="5.2.2">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.dataflowanalysis.pcm.extension</groupId>
 	<artifactId>parent</artifactId>	
-	<version>5.2.1-SNAPSHOT</version>
+	<version>5.2.2</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/META-INF/MANIFEST.MF
+++ b/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Workflow
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.commons.logging,

--- a/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/pom.xml
+++ b/releng/org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.dataflowanalysis.pcm.extension</groupId>
 		<artifactId>parent</artifactId>
-		<version>5.2.1-SNAPSHOT</version>
+		<version>5.2.2</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.dataflowanalysis.pcm.extension.dictionary.characterized.mwe2</artifactId>	

--- a/releng/org.dataflowanalysis.pcm.extension.dictionary.mwe2/META-INF/MANIFEST.MF
+++ b/releng/org.dataflowanalysis.pcm.extension.dictionary.mwe2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Data Flow Diagram MWE2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.mwe2
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.mwe2
 Require-Bundle: org.eclipse.emf.mwe2.launch;bundle-version="2.10.0",
  org.eclipse.emf.mwe2.lib,

--- a/releng/org.dataflowanalysis.pcm.extension.mwe2/META-INF/MANIFEST.MF
+++ b/releng/org.dataflowanalysis.pcm.extension.mwe2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mwe2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.mwe2
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.mwe2
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.commons.logging,

--- a/releng/org.dataflowanalysis.pcm.extension.mwe2/pom.xml
+++ b/releng/org.dataflowanalysis.pcm.extension.mwe2/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.dataflowanalysis.pcm.extension</groupId>
 		<artifactId>parent</artifactId>
-		<version>5.2.1-SNAPSHOT</version>
+		<version>5.2.2</version>
 		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.dataflowanalysis.pcm.extension.mwe2</artifactId>	

--- a/releng/org.dataflowanalysis.pcm.extension.nodecharacteristics.mwe2/META-INF/MANIFEST.MF
+++ b/releng/org.dataflowanalysis.pcm.extension.nodecharacteristics.mwe2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: MWE2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.nodecharacteristics.mwe2
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.nodecharacteristics.mwe2
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.emf.mwe2.launch,

--- a/releng/org.dataflowanalysis.pcm.extension.targetplatform/org.dataflowanalysis.pcm.extension.targetplatform.target
+++ b/releng/org.dataflowanalysis.pcm.extension.targetplatform/org.dataflowanalysis.pcm.extension.targetplatform.target
@@ -181,7 +181,7 @@
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.cost.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-costefficiency/releases/5.1.0/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-costefficiency/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">

--- a/releng/org.dataflowanalysis.pcm.extension.targetplatform/org.dataflowanalysis.pcm.extension.targetplatform.target
+++ b/releng/org.dataflowanalysis.pcm.extension.targetplatform/org.dataflowanalysis.pcm.extension.targetplatform.target
@@ -16,167 +16,167 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.pcm" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.editors.commons.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.editors.sirius.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-editors-sirius/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-editors-sirius/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.architecturaltemplates.api" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-addon-architecturaltemplates/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-addon-architecturaltemplates/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.modelversioning.emfprofile.ui.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.workflow.feature.mdsd.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-workflowengine/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-workflowengine/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.yakindu.base.xtext.utils.gmf.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-yakindustatecharts/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-yakindustatecharts/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.library.emfeditutils.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/library-emfeditutils/nightly/"/>
+			<repository location="https://updatesite.mdsd.tools/library-emfeditutils/releases/1.0.0/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.junit5utils.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/library-junit5utils/nightly/"/>
+			<repository location="https://updatesite.mdsd.tools/library-junit5utils/releases/1.0.0/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.library.standalone.initialization.log4j.feature.feature.group" version="0.0.0"/>
 			<unit id="tools.mdsd.library.standalone.initialization.emfprofiles.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/nightly/"/>
+			<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/releases/1.0.0/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.license.epl2.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/build-licensefeature/nightly/"/>
+			<repository location="https://updatesite.mdsd.tools/build-licensefeature/releases/1.0.0/"/>
 		</location>
 
 		<!-- transitively required by Palladio editors -->
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.edp2" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-edp2/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-edp2/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.jscience" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.measurementframework" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.metricspec" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.analyzer.workflow" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-framework/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-framework/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.featureconfig" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-featuremodel/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-featuremodel/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.codegen.simucontroller" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simucom/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simucom/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.recorderframework" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-recorderframework/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-recorderframework/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.reliability" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-reliability/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-reliability/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.simulation.abstractsimengine" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-simulation-abstractsimengine/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-simulation-abstractsimengine/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.scheduler" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-simulation-scheduler/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-simulation-scheduler/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.probeframework" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-probeframework/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-probeframework/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.simulizar.ui" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simulizar/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-simulizar/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.monitorrepository" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-monitorrepository/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-monitorrepository/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.servicelevelobjective" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-servicelevelobjectives/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-servicelevelobjectives/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.experimentautomation.application" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-experimentautomation/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-experimentautomation/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="com.google.dagger.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.mdsd.tools/thirdparty-library/nightly/"/>
+			<repository location="https://updatesite.mdsd.tools/thirdparty-library/releases/1.0.0/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.examples.package.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-example-models-package/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-example-models-package/releases/5.2.2/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.descartes.dlim.feature.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-limbo/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-limbo/releases/5.2.2/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.scaledl.usageevolution" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-cloudscaleusageevolution/nightly/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-cloudscaleusageevolution/releases/5.2.2/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">

--- a/releng/org.dataflowanalysis.pcm.extension.targetplatform/org.dataflowanalysis.pcm.extension.targetplatform.target
+++ b/releng/org.dataflowanalysis.pcm.extension.targetplatform/org.dataflowanalysis.pcm.extension.targetplatform.target
@@ -56,7 +56,7 @@
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.yakindu.base.xtext.utils.gmf.feature.group" version="0.0.0"/>
-			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-yakindustatecharts/releases/5.2.2/"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-yakindustatecharts/releases/5.1.0/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -4,12 +4,12 @@
 	<parent>
 		<groupId>org.dataflowanalysis.pcm.extension</groupId>
 		<artifactId>parent</artifactId>
-		<version>5.2.1-SNAPSHOT</version>
+		<version>5.2.2</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<groupId>org.dataflowanalysis.pcm.extension</groupId>
 	<artifactId>releng</artifactId>	
-	<version>5.2.1-SNAPSHOT</version>
+	<version>5.2.2</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/tests/org.dataflowanalysis.pcm.extension.dddsl.tests/META-INF/MANIFEST.MF
+++ b/tests/org.dataflowanalysis.pcm.extension.dddsl.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dddsl.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dddsl.tests
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dddsl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dddsl,

--- a/tests/org.dataflowanalysis.pcm.extension.dddsl.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.dataflowanalysis.pcm.extension.dddsl.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dddsl.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dddsl.ui.tests
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dddsl.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dddsl.ui,

--- a/tests/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.tests/META-INF/MANIFEST.MF
+++ b/tests/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characteriz
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.tests
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl,

--- a/tests/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.dataflowanalysis.pcm.extension.dictionary.characteriz
 Bundle-ManifestVersion: 2
 Bundle-Name: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui.tests
 Bundle-Vendor: My Company
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dataflowanalysis.pcm.extension.dictionary.characterized.dsl.ui,

--- a/tests/org.dataflowanalysis.pcm.extension.model.edit.test/META-INF/MANIFEST.MF
+++ b/tests/org.dataflowanalysis.pcm.extension.model.edit.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PCM Confidentiality Edit Test
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.model.edit.test
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.model.edit.test
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.dataflowanalysis.pcm.extension.model.edit,

--- a/tests/org.dataflowanalysis.pcm.extension.testmodels/META-INF/MANIFEST.MF
+++ b/tests/org.dataflowanalysis.pcm.extension.testmodels/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Testmodels
 Bundle-SymbolicName: org.dataflowanalysis.pcm.extension.testmodels
-Bundle-Version: 5.2.1.qualifier
+Bundle-Version: 5.2.2
 Automatic-Module-Name: org.dataflowanalysis.pcm.extension.testmodels
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
I have updated the version numbers in multiple files to 5.2.2 for the Palladio release and to 1.0.0 for mdsdtools release.

Changed were POM, MANIFEST and .targetplattform files.

The POM file is still on the same version (0.10.0).

My local build is a success.